### PR TITLE
added $config to to keep connection configs accessible

### DIFF
--- a/src/TCK/Odbc/OdbcServiceProvider.php
+++ b/src/TCK/Odbc/OdbcServiceProvider.php
@@ -50,7 +50,7 @@ class OdbcServiceProvider extends ServiceProvider {
 			$connector = new ODBCConnector();
 			$pdo       = $connector->connect( $config );
 
-			return new ODBCConnection( $pdo, $config['database'], $config['prefix'] );
+			return new ODBCConnection( $pdo, $config['database'], $config['prefix'], $config );
 
 		} );
 	}


### PR DESCRIPTION
The service provider isn't passing $config as the 4th parameter, so any calls to ->getConfig will return nothing and ->config is always empty.
