### PR TITLE
Fix connection name reverting to default for writes

### DIFF
--- a/src/TCK/Odbc/OdbcServiceProvider.php
+++ b/src/TCK/Odbc/OdbcServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace TCK\Odbc;
 
+use Illuminate\Database\Connection;
 use Illuminate\Support\ServiceProvider;
 
 class OdbcServiceProvider extends ServiceProvider {
@@ -39,20 +40,17 @@ class OdbcServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$factory = $this->app['db'];
-		$factory->extend( 'odbc', function ( $config )
-		{
-			if ( ! isset( $config['prefix'] ) )
-			{
-				$config['prefix'] = '';
-			}
+		Connection::resolverFor('odbc', function ($connection, $database, $prefix, $config) {
+            if ( ! isset( $config['prefix'] ) )
+            {
+                $config['prefix'] = '';
+            }
 
-			$connector = new ODBCConnector();
-			$pdo       = $connector->connect( $config );
+            $connector = new ODBCConnector();
+            $pdo       = $connector->connect( $config );
 
-			return new ODBCConnection( $pdo, $config['database'], $config['prefix'] );
-
-		} );
+            return new ODBCConnection($pdo, $database, $config['prefix'], $config);
+        });
 	}
 
 }


### PR DESCRIPTION
Change to the `Connection::resolveFor()` method over binding directly.

This change also passes the config array into the `ODBCConnection`, allowing Builder to get the connection name when writing.

This is a breaking change for Laravel 5.4 compatibility.